### PR TITLE
un-deprecate --cxxstd. use default value from setup.cfg and always pa…

### DIFF
--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -1,0 +1,2 @@
+[build_ext]
+cxxstd = 11


### PR DESCRIPTION
…ss cxxstd= (depending on b2 version)